### PR TITLE
Add API for custom unhandled exception handling in WindowsApplication.

### DIFF
--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -121,15 +121,9 @@ jobs:
           Get-CimInstance Win32_SoundDevice | fl * # Print audio device info.
 
       - name: Execute performance benchmarks
-        id: execute-performance-benchmarks
-        timeout-minutes: 10
         run: |
           cd benchmark\Benchmark\bin\Release\netcoreapp3.1\
           .\Benchmark.exe | Out-Default
-
-      - name: Print engine log if benchmark fails
-        if: failure() && steps.execute-performance-benchmarks.outcome == 'failure'
-        run: Write-Host (Get-Content .\benchmark\Benchmark\bin\Release\netcoreapp3.1\GeishaEngine.log -Raw)
 
       - name: Copy benchmark results to benchmark-results directory
         run: |

--- a/benchmark/Benchmark/Benchmarks/EmptyScene/EmptySceneSceneBehaviorFactory.cs
+++ b/benchmark/Benchmark/Benchmarks/EmptyScene/EmptySceneSceneBehaviorFactory.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Geisha.Engine.Core.SceneModel;
+﻿using Geisha.Engine.Core.SceneModel;
 
 namespace Benchmark.Benchmarks.EmptyScene
 {
@@ -21,7 +20,6 @@ namespace Benchmark.Benchmarks.EmptyScene
 
             protected override void OnLoaded()
             {
-                throw new InvalidOperationException("TEST");
             }
         }
     }

--- a/benchmark/Benchmark/Benchmarks/EmptyScene/EmptySceneSceneBehaviorFactory.cs
+++ b/benchmark/Benchmark/Benchmarks/EmptyScene/EmptySceneSceneBehaviorFactory.cs
@@ -1,4 +1,5 @@
-﻿using Geisha.Engine.Core.SceneModel;
+﻿using System;
+using Geisha.Engine.Core.SceneModel;
 
 namespace Benchmark.Benchmarks.EmptyScene
 {
@@ -20,6 +21,7 @@ namespace Benchmark.Benchmarks.EmptyScene
 
             protected override void OnLoaded()
             {
+                throw new InvalidOperationException("TEST");
             }
         }
     }

--- a/benchmark/Benchmark/Program.cs
+++ b/benchmark/Benchmark/Program.cs
@@ -11,7 +11,13 @@ namespace Benchmark
         [STAThread]
         private static void Main()
         {
+            WindowsApplication.UnhandledExceptionHandler = UnhandledExceptionHandler;
             WindowsApplication.Run(new Game());
+        }
+
+        private static void UnhandledExceptionHandler(object sender, UnhandledExceptionEventArgs e)
+        {
+            Environment.FailFast(e.ExceptionObject.ToString());
         }
     }
 }

--- a/src/Geisha.Engine.Windows/WindowsApplication.cs
+++ b/src/Geisha.Engine.Windows/WindowsApplication.cs
@@ -18,12 +18,18 @@ namespace Geisha.Engine.Windows
         private const string LogFile = "GeishaEngine.log";
 
         /// <summary>
+        ///     Gets or sets handler to be used for unhandled exceptions.
+        /// </summary>
+        /// <remarks>Default handler shows the message box with information about fatal error and points to log file for details.</remarks>
+        public static UnhandledExceptionEventHandler UnhandledExceptionHandler { get; set; } = CurrentDomainOnUnhandledException;
+
+        /// <summary>
         ///     Initializes Geisha Engine for specified <paramref name="game" /> and starts the game loop.
         /// </summary>
         /// <param name="game"><see cref="IGame" /> instance providing custom game functionality.</param>
         public static void Run(IGame game)
         {
-            AppDomain.CurrentDomain.UnhandledException += CurrentDomainOnUnhandledException;
+            AppDomain.CurrentDomain.UnhandledException += UnhandledExceptionHandler;
 
             LogFactory.ConfigureFileTarget(LogFile);
 

--- a/src/Geisha.Engine.Windows/WindowsApplication.cs
+++ b/src/Geisha.Engine.Windows/WindowsApplication.cs
@@ -21,7 +21,7 @@ namespace Geisha.Engine.Windows
         ///     Gets or sets handler to be used for unhandled exceptions.
         /// </summary>
         /// <remarks>Default handler shows the message box with information about fatal error and points to log file for details.</remarks>
-        public static UnhandledExceptionEventHandler UnhandledExceptionHandler { get; set; } = CurrentDomainOnUnhandledException;
+        public static UnhandledExceptionEventHandler UnhandledExceptionHandler { get; set; } = DefaultUnhandledExceptionHandler;
 
         /// <summary>
         ///     Initializes Geisha Engine for specified <paramref name="game" /> and starts the game loop.
@@ -69,7 +69,7 @@ namespace Geisha.Engine.Windows
             log.Info("Engine shutdown completed.");
         }
 
-        private static void CurrentDomainOnUnhandledException(object sender, UnhandledExceptionEventArgs unhandledExceptionEventArgs)
+        private static void DefaultUnhandledExceptionHandler(object sender, UnhandledExceptionEventArgs unhandledExceptionEventArgs)
         {
             var exceptionObject = unhandledExceptionEventArgs.ExceptionObject;
             var log = LogFactory.Create(typeof(WindowsApplication));


### PR DESCRIPTION
Property UnhandledExceptionHandler was added to WindowsApplication.
Benchmark uses UnhandledExceptionHandler API to fail fast in case of exception.
For testing purposes Benchmark throws unhandled exception.