### PR TITLE
#599 Fix documentation build

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,10 +3,11 @@
   "isRoot": true,
   "tools": {
     "docfx": {
-      "version": "2.70.0",
+      "version": "2.78.3",
       "commands": [
         "docfx"
-      ]
+      ],
+      "rollForward": false
     }
   }
 }

--- a/.github/workflows/build-and-publish-documentation.yml
+++ b/.github/workflows/build-and-publish-documentation.yml
@@ -19,6 +19,12 @@ jobs:
         uses: actions/checkout@v4
         with:
           lfs: true
+          fetch-depth: 0
+
+      - name: Set up .NET SDK
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 6.0.x
 
       - name: Build documentation
         run: .\scripts\build-documentation.ps1


### PR DESCRIPTION
Bump DocFX tool version from 2.70.0 to 2.78.3 and add 'rollForward' setting in dotnet-tools.json. Update GitHub Actions workflow to set up .NET SDK 6.0.x and fetch full git history for documentation build.