### PR TITLE
#630 Remove excessive allocations in UpdateRenderList

### DIFF
--- a/src/Geisha.Engine.Rendering.DirectX/RenderingContext2D.cs
+++ b/src/Geisha.Engine.Rendering.DirectX/RenderingContext2D.cs
@@ -174,16 +174,16 @@ namespace Geisha.Engine.Rendering.DirectX
 
             try
             {
-                var spanOfSprites = spriteBatch.GetSpanAccess();
-                for (var i = 0; i < spanOfSprites.Length; i++)
+                var sprites = spriteBatch.GetSpritesSpan();
+                for (var i = 0; i < sprites.Length; i++)
                 {
-                    var sprite = spanOfSprites[i].Sprite;
+                    var sprite = sprites[i].Sprite;
 
                     destinationRectangles[i] = sprite.Rectangle.ToRawRectangleF();
                     sourceRectangles[i] = new RawRectangle((int)sprite.SourceUV.X, (int)sprite.SourceUV.Y,
                         (int)(sprite.SourceUV.X + sprite.SourceDimensions.X), (int)(sprite.SourceUV.Y + sprite.SourceDimensions.Y));
-                    colors[i] = new RawColor4(1f, 1f, 1f, (float)spanOfSprites[i].Opacity);
-                    dxTransforms[i] = ConvertTransformToDirectX(spanOfSprites[i].Transform);
+                    colors[i] = new RawColor4(1f, 1f, 1f, (float)sprites[i].Opacity);
+                    dxTransforms[i] = ConvertTransformToDirectX(sprites[i].Transform);
                 }
 
                 using var d2D1SpriteBatch = new SharpDX.Direct2D1.SpriteBatch(_d2D1DeviceContext);

--- a/src/Geisha.Engine/Rendering/Backend/SpriteBatch.cs
+++ b/src/Geisha.Engine/Rendering/Backend/SpriteBatch.cs
@@ -61,7 +61,7 @@ public sealed class SpriteBatch
     ///     <see cref="SpriteBatch" /> should not be modified while <see cref="Span{T}" /> is in use.
     /// </summary>
     /// <returns><see cref="Span{T}" /> view over sprites contained in the <see cref="SpriteBatch" />.</returns>
-    public Span<SpriteBatchElement> GetSpanAccess()
+    public Span<SpriteBatchElement> GetSpritesSpan()
     {
         return CollectionsMarshal.AsSpan(_sprites);
     }

--- a/src/Geisha.Engine/Rendering/Systems/Renderer.cs
+++ b/src/Geisha.Engine/Rendering/Systems/Renderer.cs
@@ -165,10 +165,10 @@ internal sealed class Renderer : IRenderNodeVisitor
         Debug.Assert(_renderingState.CameraNode != null, "_renderingState.CameraNode != null");
         var boundingRectangleOfView = _renderingState.CameraNode.GetBoundingRectangleOfView();
 
-        foreach (var sortingLayer in _renderingState.GetSortingLayers())
+        foreach (var sortingLayer in _renderingState.GetSortingLayersSpan())
         {
             _sortingBuffer.Clear();
-            foreach (var renderNode in sortingLayer.GetRenderNodes())
+            foreach (var renderNode in sortingLayer.GetRenderNodesSpan())
             {
                 if (renderNode.ShouldSkipRendering()) continue;
                 if (!boundingRectangleOfView.Overlaps(renderNode.GetBoundingRectangle())) continue;
@@ -219,8 +219,8 @@ internal sealed class Renderer : IRenderNodeVisitor
 
         if (_spriteBatch.Count == 1)
         {
-            var spanOfSprites = _spriteBatch.GetSpanAccess();
-            _renderingContext2D.DrawSprite(spanOfSprites[0].Sprite, spanOfSprites[0].Transform, spanOfSprites[0].Opacity);
+            var sprites = _spriteBatch.GetSpritesSpan();
+            _renderingContext2D.DrawSprite(sprites[0].Sprite, sprites[0].Transform, sprites[0].Opacity);
         }
         else
         {

--- a/src/Geisha.Engine/Rendering/Systems/RenderingState.cs
+++ b/src/Geisha.Engine/Rendering/Systems/RenderingState.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.InteropServices;
 using Geisha.Engine.Core.Components;
 using Geisha.Engine.Core.SceneModel;
 using Geisha.Engine.Rendering.Backend;
@@ -26,7 +27,7 @@ internal sealed class RenderingState
 
     public CameraNode? CameraNode { get; private set; }
 
-    public IReadOnlyList<SortingLayer> GetSortingLayers() => _sortingLayers;
+    public ReadOnlySpan<SortingLayer> GetSortingLayersSpan() => CollectionsMarshal.AsSpan(_sortingLayers);
 
     public void CreateStateFor(Transform2DComponent transform2DComponent)
     {

--- a/src/Geisha.Engine/Rendering/Systems/SortingLayer.cs
+++ b/src/Geisha.Engine/Rendering/Systems/SortingLayer.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
 
 namespace Geisha.Engine.Rendering.Systems;
 
@@ -13,7 +15,7 @@ internal sealed class SortingLayer
 
     public string Name { get; }
 
-    public IReadOnlyList<RenderNode> GetRenderNodes() => _renderNodes;
+    public ReadOnlySpan<RenderNode> GetRenderNodesSpan() => CollectionsMarshal.AsSpan(_renderNodes);
 
     public void Add(RenderNode node)
     {

--- a/test/Geisha.Engine.UnitTests/Rendering/Backend/SpriteBatchTests.cs
+++ b/test/Geisha.Engine.UnitTests/Rendering/Backend/SpriteBatchTests.cs
@@ -120,7 +120,7 @@ public class SpriteBatchTests
     }
 
     [Test]
-    public void GetSpanAccess_ShouldReturnSpanThatGivesAccessToSpritesAddedToBatch()
+    public void GetSpritesSpan_ShouldReturnSpanThatGivesAccessToSpritesAddedToBatch()
     {
         // Arrange
         var spriteBatch = new SpriteBatch();
@@ -135,22 +135,22 @@ public class SpriteBatchTests
         spriteBatch.AddSprite(sprite3, Matrix3x3.CreateRotation(3), 0.3);
 
         // Act
-        var spanOfSprites = spriteBatch.GetSpanAccess();
+        var sprites = spriteBatch.GetSpritesSpan();
 
         // Assert
-        Assert.That(spanOfSprites.Length, Is.EqualTo(3));
+        Assert.That(sprites.Length, Is.EqualTo(3));
 
-        Assert.That(spanOfSprites[0].Sprite, Is.EqualTo(sprite1));
-        Assert.That(spanOfSprites[0].Transform, Is.EqualTo(Matrix3x3.CreateRotation(1)));
-        Assert.That(spanOfSprites[0].Opacity, Is.EqualTo(0.1));
+        Assert.That(sprites[0].Sprite, Is.EqualTo(sprite1));
+        Assert.That(sprites[0].Transform, Is.EqualTo(Matrix3x3.CreateRotation(1)));
+        Assert.That(sprites[0].Opacity, Is.EqualTo(0.1));
 
-        Assert.That(spanOfSprites[1].Sprite, Is.EqualTo(sprite2));
-        Assert.That(spanOfSprites[1].Transform, Is.EqualTo(Matrix3x3.CreateRotation(2)));
-        Assert.That(spanOfSprites[1].Opacity, Is.EqualTo(0.2));
+        Assert.That(sprites[1].Sprite, Is.EqualTo(sprite2));
+        Assert.That(sprites[1].Transform, Is.EqualTo(Matrix3x3.CreateRotation(2)));
+        Assert.That(sprites[1].Opacity, Is.EqualTo(0.2));
 
-        Assert.That(spanOfSprites[2].Sprite, Is.EqualTo(sprite3));
-        Assert.That(spanOfSprites[2].Transform, Is.EqualTo(Matrix3x3.CreateRotation(3)));
-        Assert.That(spanOfSprites[2].Opacity, Is.EqualTo(0.3));
+        Assert.That(sprites[2].Sprite, Is.EqualTo(sprite3));
+        Assert.That(sprites[2].Transform, Is.EqualTo(Matrix3x3.CreateRotation(3)));
+        Assert.That(sprites[2].Opacity, Is.EqualTo(0.3));
     }
 
     private static ITexture CreateTexture()

--- a/test/Geisha.Engine.UnitTests/Rendering/Systems/RenderingSystemTests/RenderingOrderTests.cs
+++ b/test/Geisha.Engine.UnitTests/Rendering/Systems/RenderingSystemTests/RenderingOrderTests.cs
@@ -134,7 +134,7 @@ public class RenderingOrderTests : RenderingSystemTestsBase
             Assert.That(spriteBatch.Count, Is.EqualTo(3));
             Assert.That(spriteBatch.Texture, Is.EqualTo(texture));
 
-            var sprites = spriteBatch.GetSpanAccess().ToArray();
+            var sprites = spriteBatch.GetSpritesSpan().ToArray();
             Assert.That(sprites[0].Sprite, Is.EqualTo(entity2.GetSprite()));
             Assert.That(sprites[1].Sprite, Is.EqualTo(entity3.GetSprite()));
             Assert.That(sprites[2].Sprite, Is.EqualTo(entity1.GetSprite()));
@@ -171,7 +171,7 @@ public class RenderingOrderTests : RenderingSystemTestsBase
             Assert.That(spriteBatch.Count, Is.EqualTo(3));
             Assert.That(spriteBatch.Texture, Is.EqualTo(texture));
 
-            var sprites = spriteBatch.GetSpanAccess().ToArray();
+            var sprites = spriteBatch.GetSpritesSpan().ToArray();
             Assert.That(sprites[0].Sprite, Is.EqualTo(entity2.GetSprite()));
             Assert.That(sprites[1].Sprite, Is.EqualTo(entity3.GetSprite()));
             Assert.That(sprites[2].Sprite, Is.EqualTo(entity1.GetSprite()));
@@ -209,7 +209,7 @@ public class RenderingOrderTests : RenderingSystemTestsBase
             Assert.That(spriteBatch.Count, Is.EqualTo(2));
             Assert.That(spriteBatch.Texture, Is.EqualTo(texture));
 
-            var sprites = spriteBatch.GetSpanAccess().ToArray();
+            var sprites = spriteBatch.GetSpritesSpan().ToArray();
             Assert.That(sprites[0].Sprite, Is.EqualTo(entity2.GetSprite()));
             Assert.That(sprites[1].Sprite, Is.EqualTo(entity1.GetSprite()));
         });

--- a/test/Geisha.Engine.UnitTests/Rendering/Systems/RenderingSystemTests/SpriteRendererComponentTests.cs
+++ b/test/Geisha.Engine.UnitTests/Rendering/Systems/RenderingSystemTests/SpriteRendererComponentTests.cs
@@ -152,7 +152,7 @@ public class SpriteRendererComponentTests : RenderingSystemTestsBase
             Assert.That(spriteBatch.Count, Is.EqualTo(2));
             Assert.That(spriteBatch.Texture, Is.EqualTo(texture));
 
-            var sprites = spriteBatch.GetSpanAccess().ToArray();
+            var sprites = spriteBatch.GetSpritesSpan().ToArray();
             var spriteBatchElement1 = sprites.Single(s => s.Sprite == entity1.GetSprite());
             var spriteBatchElement2 = sprites.Single(s => s.Sprite == entity2.GetSprite());
 
@@ -193,7 +193,7 @@ public class SpriteRendererComponentTests : RenderingSystemTestsBase
             Assert.That(spriteBatch.Count, Is.EqualTo(2));
             Assert.That(spriteBatch.Texture, Is.EqualTo(texture));
 
-            var sprites = spriteBatch.GetSpanAccess().ToArray();
+            var sprites = spriteBatch.GetSpritesSpan().ToArray();
             Assert.That(sprites, Has.One.Matches<SpriteBatchElement>(s => s.Sprite == entity1.GetSprite()));
             Assert.That(sprites, Has.One.Matches<SpriteBatchElement>(s => s.Sprite == entity3.GetSprite()));
         });
@@ -207,7 +207,7 @@ public class SpriteRendererComponentTests : RenderingSystemTestsBase
     }
 
     [Test]
-    public void RenderScene_ShouldDrawSpriteBatchAndDrawAnotherSpriteBatch_WhenSceneContainsTwoSpritesWithTheSameTextureAndTwoSpriteWithOtherTexture()
+    public void RenderScene_ShouldDrawSpriteBatchAndDrawAnotherSpriteBatch_WhenSceneContainsTwoSpritesWithTheSameTextureAndTwoSpritesWithOtherTexture()
     {
         // Arrange
         var (renderingSystem, renderingScene) = GetRenderingSystem();
@@ -236,7 +236,7 @@ public class SpriteRendererComponentTests : RenderingSystemTestsBase
                 Assert.That(spriteBatch.Count, Is.EqualTo(2));
                 Assert.That(spriteBatch.Texture, Is.EqualTo(texture1));
 
-                var sprites = spriteBatch.GetSpanAccess().ToArray();
+                var sprites = spriteBatch.GetSpritesSpan().ToArray();
                 Assert.That(sprites, Has.One.Matches<SpriteBatchElement>(s => s.Sprite == entity1.GetSprite()));
                 Assert.That(sprites, Has.One.Matches<SpriteBatchElement>(s => s.Sprite == entity3.GetSprite()));
             }
@@ -245,7 +245,7 @@ public class SpriteRendererComponentTests : RenderingSystemTestsBase
                 Assert.That(spriteBatch.Count, Is.EqualTo(2));
                 Assert.That(spriteBatch.Texture, Is.EqualTo(texture2));
 
-                var sprites = spriteBatch.GetSpanAccess().ToArray();
+                var sprites = spriteBatch.GetSpritesSpan().ToArray();
                 Assert.That(sprites, Has.One.Matches<SpriteBatchElement>(s => s.Sprite == entity2.GetSprite()));
                 Assert.That(sprites, Has.One.Matches<SpriteBatchElement>(s => s.Sprite == entity4.GetSprite()));
             }


### PR DESCRIPTION
Refactor span access methods for rendering collections. Renamed methods for accessing internal spans in SpriteBatch, RenderingState, and SortingLayer to more descriptive names (e.g., GetSpanAccess to GetSpritesSpan). Updated all usages and related unit tests to reflect the new method names. This improves code clarity and consistency when working with spans of rendering elements.