### PR TITLE
#631 Refactor step duration recording in performance statistics

### DIFF
--- a/src/Geisha.Engine/Core/GameLoop/GameLoop.cs
+++ b/src/Geisha.Engine/Core/GameLoop/GameLoop.cs
@@ -49,33 +49,28 @@ namespace Geisha.Engine.Core.GameLoop
 
             while (_timeToSimulate >= GameTime.FixedDeltaTime && (fixedUpdatesPerFrame < _fixedUpdatesPerFrameLimit || _fixedUpdatesPerFrameLimit == 0))
             {
-                using (_performanceStatisticsRecorder.RecordStepDuration(_gameLoopSteps.InputStepName))
-                {
-                    _gameLoopSteps.InputStep.ProcessInput();
-                }
+                _performanceStatisticsRecorder.BeginStepDuration();
+                _gameLoopSteps.InputStep.ProcessInput();
+                _performanceStatisticsRecorder.EndStepDuration(_gameLoopSteps.InputStepName);
 
-                using (_performanceStatisticsRecorder.RecordStepDuration(_gameLoopSteps.BehaviorStepName))
-                {
-                    _gameLoopSteps.BehaviorStep.ProcessBehaviorFixedUpdate();
-                }
+                _performanceStatisticsRecorder.BeginStepDuration();
+                _gameLoopSteps.BehaviorStep.ProcessBehaviorFixedUpdate();
+                _performanceStatisticsRecorder.EndStepDuration(_gameLoopSteps.BehaviorStepName);
 
-                using (_performanceStatisticsRecorder.RecordStepDuration(_gameLoopSteps.CoroutineStepName))
-                {
-                    _gameLoopSteps.CoroutineStep.ProcessCoroutines();
-                }
+                _performanceStatisticsRecorder.BeginStepDuration();
+                _gameLoopSteps.CoroutineStep.ProcessCoroutines();
+                _performanceStatisticsRecorder.EndStepDuration(_gameLoopSteps.CoroutineStepName);
 
                 foreach (var customStep in _gameLoopSteps.CustomSteps)
                 {
-                    using (_performanceStatisticsRecorder.RecordStepDuration(customStep.Name))
-                    {
-                        customStep.ProcessFixedUpdate();
-                    }
+                    _performanceStatisticsRecorder.BeginStepDuration();
+                    customStep.ProcessFixedUpdate();
+                    _performanceStatisticsRecorder.EndStepDuration(customStep.Name);
                 }
 
-                using (_performanceStatisticsRecorder.RecordStepDuration(_gameLoopSteps.PhysicsStepName))
-                {
-                    _gameLoopSteps.PhysicsStep.ProcessPhysics();
-                }
+                _performanceStatisticsRecorder.BeginStepDuration();
+                _gameLoopSteps.PhysicsStep.ProcessPhysics();
+                _performanceStatisticsRecorder.EndStepDuration(_gameLoopSteps.PhysicsStepName);
 
                 scene.RemoveEntitiesAfterFixedTimeStep();
 
@@ -83,43 +78,36 @@ namespace Geisha.Engine.Core.GameLoop
                 fixedUpdatesPerFrame++;
             }
 
-            using (_performanceStatisticsRecorder.RecordStepDuration(_gameLoopSteps.BehaviorStepName))
-            {
-                _gameLoopSteps.BehaviorStep.ProcessBehaviorUpdate(gameTime);
-            }
+            _performanceStatisticsRecorder.BeginStepDuration();
+            _gameLoopSteps.BehaviorStep.ProcessBehaviorUpdate(gameTime);
+            _performanceStatisticsRecorder.EndStepDuration(_gameLoopSteps.BehaviorStepName);
 
-            using (_performanceStatisticsRecorder.RecordStepDuration(_gameLoopSteps.CoroutineStepName))
-            {
-                _gameLoopSteps.CoroutineStep.ProcessCoroutines(gameTime);
-            }
+            _performanceStatisticsRecorder.BeginStepDuration();
+            _gameLoopSteps.CoroutineStep.ProcessCoroutines(gameTime);
+            _performanceStatisticsRecorder.EndStepDuration(_gameLoopSteps.CoroutineStepName);
 
             foreach (var customStep in _gameLoopSteps.CustomSteps)
             {
-                using (_performanceStatisticsRecorder.RecordStepDuration(customStep.Name))
-                {
-                    customStep.ProcessUpdate(gameTime);
-                }
+                _performanceStatisticsRecorder.BeginStepDuration();
+                customStep.ProcessUpdate(gameTime);
+                _performanceStatisticsRecorder.EndStepDuration(customStep.Name);
             }
 
-            using (_performanceStatisticsRecorder.RecordStepDuration(_gameLoopSteps.PhysicsStepName))
-            {
-                _gameLoopSteps.PhysicsStep.PreparePhysicsDebugInformation();
-            }
+            _performanceStatisticsRecorder.BeginStepDuration();
+            _gameLoopSteps.PhysicsStep.PreparePhysicsDebugInformation();
+            _performanceStatisticsRecorder.EndStepDuration(_gameLoopSteps.PhysicsStepName);
 
-            using (_performanceStatisticsRecorder.RecordStepDuration(_gameLoopSteps.AudioStepName))
-            {
-                _gameLoopSteps.AudioStep.ProcessAudio();
-            }
+            _performanceStatisticsRecorder.BeginStepDuration();
+            _gameLoopSteps.AudioStep.ProcessAudio();
+            _performanceStatisticsRecorder.EndStepDuration(_gameLoopSteps.AudioStepName);
 
-            using (_performanceStatisticsRecorder.RecordStepDuration(_gameLoopSteps.AnimationStepName))
-            {
-                _gameLoopSteps.AnimationStep.ProcessAnimations(gameTime);
-            }
+            _performanceStatisticsRecorder.BeginStepDuration();
+            _gameLoopSteps.AnimationStep.ProcessAnimations(gameTime);
+            _performanceStatisticsRecorder.EndStepDuration(_gameLoopSteps.AnimationStepName);
 
-            using (_performanceStatisticsRecorder.RecordStepDuration(_gameLoopSteps.RenderingStepName))
-            {
-                _gameLoopSteps.RenderingStep.RenderScene();
-            }
+            _performanceStatisticsRecorder.BeginStepDuration();
+            _gameLoopSteps.RenderingStep.RenderScene();
+            _performanceStatisticsRecorder.EndStepDuration(_gameLoopSteps.RenderingStepName);
 
             scene.RemoveEntitiesAfterFullFrame();
 

--- a/test/Geisha.Engine.UnitTests/Core/GameLoop/GameLoopTests.cs
+++ b/test/Geisha.Engine.UnitTests/Core/GameLoop/GameLoopTests.cs
@@ -233,22 +233,38 @@ namespace Geisha.Engine.UnitTests.Core.GameLoop
             // Assert
             Received.InOrder(() =>
             {
-                _performanceStatisticsRecorder.RecordStepDuration(InputStepName);
-                _performanceStatisticsRecorder.RecordStepDuration(BehaviorStepName);
-                _performanceStatisticsRecorder.RecordStepDuration(CoroutineStepName);
-                _performanceStatisticsRecorder.RecordStepDuration(CustomStep1Name);
-                _performanceStatisticsRecorder.RecordStepDuration(CustomStep2Name);
-                _performanceStatisticsRecorder.RecordStepDuration(CustomStep3Name);
-                _performanceStatisticsRecorder.RecordStepDuration(PhysicsStepName);
-                _performanceStatisticsRecorder.RecordStepDuration(BehaviorStepName);
-                _performanceStatisticsRecorder.RecordStepDuration(CoroutineStepName);
-                _performanceStatisticsRecorder.RecordStepDuration(CustomStep1Name);
-                _performanceStatisticsRecorder.RecordStepDuration(CustomStep2Name);
-                _performanceStatisticsRecorder.RecordStepDuration(CustomStep3Name);
-                _performanceStatisticsRecorder.RecordStepDuration(PhysicsStepName);
-                _performanceStatisticsRecorder.RecordStepDuration(AudioStepName);
-                _performanceStatisticsRecorder.RecordStepDuration(AnimationStepName);
-                _performanceStatisticsRecorder.RecordStepDuration(RenderingStepName);
+                _performanceStatisticsRecorder.BeginStepDuration();
+                _performanceStatisticsRecorder.EndStepDuration(InputStepName);
+                _performanceStatisticsRecorder.BeginStepDuration();
+                _performanceStatisticsRecorder.EndStepDuration(BehaviorStepName);
+                _performanceStatisticsRecorder.BeginStepDuration();
+                _performanceStatisticsRecorder.EndStepDuration(CoroutineStepName);
+                _performanceStatisticsRecorder.BeginStepDuration();
+                _performanceStatisticsRecorder.EndStepDuration(CustomStep1Name);
+                _performanceStatisticsRecorder.BeginStepDuration();
+                _performanceStatisticsRecorder.EndStepDuration(CustomStep2Name);
+                _performanceStatisticsRecorder.BeginStepDuration();
+                _performanceStatisticsRecorder.EndStepDuration(CustomStep3Name);
+                _performanceStatisticsRecorder.BeginStepDuration();
+                _performanceStatisticsRecorder.EndStepDuration(PhysicsStepName);
+                _performanceStatisticsRecorder.BeginStepDuration();
+                _performanceStatisticsRecorder.EndStepDuration(BehaviorStepName);
+                _performanceStatisticsRecorder.BeginStepDuration();
+                _performanceStatisticsRecorder.EndStepDuration(CoroutineStepName);
+                _performanceStatisticsRecorder.BeginStepDuration();
+                _performanceStatisticsRecorder.EndStepDuration(CustomStep1Name);
+                _performanceStatisticsRecorder.BeginStepDuration();
+                _performanceStatisticsRecorder.EndStepDuration(CustomStep2Name);
+                _performanceStatisticsRecorder.BeginStepDuration();
+                _performanceStatisticsRecorder.EndStepDuration(CustomStep3Name);
+                _performanceStatisticsRecorder.BeginStepDuration();
+                _performanceStatisticsRecorder.EndStepDuration(PhysicsStepName);
+                _performanceStatisticsRecorder.BeginStepDuration();
+                _performanceStatisticsRecorder.EndStepDuration(AudioStepName);
+                _performanceStatisticsRecorder.BeginStepDuration();
+                _performanceStatisticsRecorder.EndStepDuration(AnimationStepName);
+                _performanceStatisticsRecorder.BeginStepDuration();
+                _performanceStatisticsRecorder.EndStepDuration(RenderingStepName);
                 _performanceStatisticsRecorder.RecordFrame();
             });
         }


### PR DESCRIPTION
Replaces IDisposable-based step duration recording with explicit BeginStepDuration and EndStepDuration methods in PerformanceStatisticsRecorder. Updates GameLoop and related unit tests to use the new API, and adds error handling for incorrect usage. This change improves clarity and control over step timing and simplifies the code structure. The unnecessary memory allocations are avoided.