### PR TITLE
Optimize sprite batch and text format management

### DIFF
--- a/src/Geisha.Engine.Rendering.DirectX/RenderingContext2D.cs
+++ b/src/Geisha.Engine.Rendering.DirectX/RenderingContext2D.cs
@@ -237,8 +237,8 @@ namespace Geisha.Engine.Rendering.DirectX
                 Math.Abs(_d2D1TextFormat.FontSize - (float)fontSize.Dips) > float.Epsilon)
             {
                 _d2D1TextFormat?.Dispose();
+                _d2D1TextFormat = new TextFormat(_dwFactory, fontFamilyName, FontWeight.Normal, FontStyle.Normal, (float)fontSize.Dips);
                 _currentFontFamilyName = fontFamilyName;
-                _d2D1TextFormat = new TextFormat(_dwFactory, _currentFontFamilyName, FontWeight.Normal, FontStyle.Normal, (float)fontSize.Dips);
             }
 
             _d2D1SolidColorBrush.Color = color.ToRawColor4();


### PR DESCRIPTION
Reuses a single SpriteBatch instance instead of creating one per draw call, improving performance and resource management. Caches and reuses TextFormat objects for DrawText to avoid unnecessary allocations and disposals. Also optimizes pixel buffer handling in bitmap creation by using ArrayPool for temporary buffers.