### PR TITLE
#720 Add MatrixBenchmarks

### DIFF
--- a/benchmark/Geisha.MicroBenchmark/MatrixBenchmarks.cs
+++ b/benchmark/Geisha.MicroBenchmark/MatrixBenchmarks.cs
@@ -17,6 +17,7 @@ public class MatrixBenchmarks
         }
     }
 
+    // To use this baseline, introduce a copy of the benchmarked method as Matrix3x3.CreateRotation_Legacy for side-by-side comparison.
     //[Benchmark(Baseline = true)]
     //public Matrix3x3 Matrix3x3_CreateRotation_Legacy()
     //{

--- a/benchmark/Geisha.MicroBenchmark/MatrixBenchmarks.cs
+++ b/benchmark/Geisha.MicroBenchmark/MatrixBenchmarks.cs
@@ -1,0 +1,43 @@
+using BenchmarkDotNet.Attributes;
+using Geisha.Engine.Core.Math;
+
+namespace Geisha.MicroBenchmark;
+
+[MemoryDiagnoser]
+[DisassemblyDiagnoser]
+public class MatrixBenchmarks
+{
+    private readonly double[] _angles = new double[10000];
+
+    public MatrixBenchmarks()
+    {
+        for (int i = 0; i < _angles.Length; i++)
+        {
+            _angles[i] = i * 0.001d;
+        }
+    }
+
+    //[Benchmark(Baseline = true)]
+    //public Matrix3x3 Matrix3x3_CreateRotation_Legacy()
+    //{
+    //    var r = Matrix3x3.Identity;
+    //    for (int i = 0; i < _angles.Length; i++)
+    //    {
+    //        r = Matrix3x3.CreateRotation_Legacy(_angles[i]);
+    //    }
+
+    //    return r;
+    //}
+
+    [Benchmark]
+    public Matrix3x3 Matrix3x3_CreateRotation()
+    {
+        var r = Matrix3x3.Identity;
+        for (int i = 0; i < _angles.Length; i++)
+        {
+            r = Matrix3x3.CreateRotation(_angles[i]);
+        }
+
+        return r;
+    }
+}

--- a/benchmark/Geisha.MicroBenchmark/Program.cs
+++ b/benchmark/Geisha.MicroBenchmark/Program.cs
@@ -6,6 +6,6 @@ internal static class Program
 {
     private static void Main()
     {
-        BenchmarkRunner.Run<PhysicsSystemBenchmarks>();
+        BenchmarkRunner.Run<MatrixBenchmarks>();
     }
 }


### PR DESCRIPTION
Introduce MatrixBenchmarks (benchmark/Geisha.MicroBenchmark/MatrixBenchmarks.cs) using BenchmarkDotNet with MemoryDiagnoser and DisassemblyDiagnoser to measure Matrix3x3.CreateRotation performance over a precomputed angles array. The legacy benchmark is left commented for reference. Update Program.cs to run MatrixBenchmarks instead of PhysicsSystemBenchmarks.